### PR TITLE
revert jinja2 to 2.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ clouddq = "clouddq.main:main"
 [tool.poetry.dependencies]
 python = "^3.8.6,<3.9.0"
 click = "^7.1.2"
-Jinja2 = "^2.11.3"
+Jinja2 = "^2.11.2"
 PyYAML = "^5.3.1"
 dbt-bigquery = "^0.18.1"
 # dbt's 3rd level dependency broken, so locking said dependency "agate" to working version 1.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==7.1.2
-jinja2==2.11.3
+jinja2==2.11.2
 pyyaml==5.4.1
 dbt-bigquery==0.18.1
 agate==1.6.1


### PR DESCRIPTION
dbt-core depends on jinja2 version 2.11.2 which means doing 'pip install .' will fail.
Reverting this dependency back to 2.11.2 until it's supported by dbt-core.