### PR TITLE
make duplicate rule return 0 rows and full count

### DIFF
--- a/clouddq/templates/dbt/macros/macros.sql
+++ b/clouddq/templates/dbt/macros/macros.sql
@@ -43,11 +43,11 @@
     '{{ rule_id }}' AS rule_id,
     '{{ fully_qualified_table_name }}' AS table_id,
     '{{ column_name }}' AS column_id,
-    {{ column_name }} AS column_value,
+    NULL AS column_value,
     (select distinct num_rows_validated from data) as num_rows_validated,
     FALSE AS simple_rule_row_is_valid,
-    COUNT(1) OVER () as complex_rule_validation_errors_count,
+    COUNT(*) as complex_rule_validation_errors_count,
   FROM (
-{{ rule_configs.get("rule_sql_expr") }}
-) custom_sql_statement_validation_errors
+    {{ rule_configs.get("rule_sql_expr") }}
+  ) custom_sql_statement_validation_errors
 {% endmacro -%}

--- a/configs/rules/complex-rules.yml
+++ b/configs/rules/complex-rules.yml
@@ -20,8 +20,13 @@ rules:
       custom_sql_arguments:
         - column_names
       custom_sql_statement: |-
-        select
-          $column_names
-        from data
-        group by $column_names
-        having count(*) > 1
+        select a.*, duplicates.*
+        from data a
+        inner join (
+          select
+            $column_names
+          from data
+          group by $column_names
+          having count(*) > 1
+        ) duplicates
+        using ($column_names)

--- a/dbt/macros/clouddq_macros.sql
+++ b/dbt/macros/clouddq_macros.sql
@@ -43,11 +43,11 @@
     '{{ rule_id }}' AS rule_id,
     '{{ fully_qualified_table_name }}' AS table_id,
     '{{ column_name }}' AS column_id,
-    {{ column_name }} AS column_value,
+    NULL AS column_value,
     (select distinct num_rows_validated from data) as num_rows_validated,
     FALSE AS simple_rule_row_is_valid,
-    COUNT(1) OVER () as complex_rule_validation_errors_count,
+    COUNT(*) as complex_rule_validation_errors_count,
   FROM (
-{{ rule_configs.get("rule_sql_expr") }}
-) custom_sql_statement_validation_errors
+    {{ rule_configs.get("rule_sql_expr") }}
+  ) custom_sql_statement_validation_errors
 {% endmacro -%}

--- a/tests/resources/configs/rules/complex-rules.yml
+++ b/tests/resources/configs/rules/complex-rules.yml
@@ -20,8 +20,13 @@ rules:
       custom_sql_arguments:
         - column_names
       custom_sql_statement: |-
-        select
-          $column_names
-        from data
-        group by $column_names
-        having count(*) > 1
+        select a.*, duplicates.*
+        from data a
+        inner join (
+          select
+            $column_names
+          from data
+          group by $column_names
+          having count(*) > 1
+        ) duplicates
+        using ($column_names)

--- a/tests/resources/test_render_run_dq_main_sql_expected_custom_sql_statement.sql
+++ b/tests/resources/test_render_run_dq_main_sql_expected_custom_sql_statement.sql
@@ -30,16 +30,21 @@ SELECT
     'NO_DUPLICATES_IN_COLUMN_GROUPS' AS rule_id,
     '<your_gcp_project_id>.dq_test.contact_details' AS table_id,
     'value' AS column_id,
-    value AS column_value,
+    NULL AS column_value,
     (select distinct num_rows_validated from data) as num_rows_validated,
     FALSE AS simple_rule_row_is_valid,
-    COUNT(1) OVER () as complex_rule_validation_errors_count,
+    COUNT(*) as complex_rule_validation_errors_count,
   FROM (
-select
-  contact_type,value
-from data
-group by contact_type,value
-having count(*) > 1
+    select a.*, duplicates.*
+    from data a
+    inner join (
+      select
+        contact_type,value
+      from data
+      group by contact_type,value
+      having count(*) > 1
+    ) duplicates
+    using (contact_type,value)
 ) custom_sql_statement_validation_errors
 
     UNION ALL


### PR DESCRIPTION
This fixes two bugs with the existing duplicates check rule:

- previously the duplicates rule returned nothing so it did not update the failure count to 0 once the duplicates are removed, with this change it returns 0 as the count
- also it will return the total number of duplicated records not just the distinct count of duplicated records

