### PR TITLE
fixing readme instructions for dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ From a `Ubuntu`/`Debian` machine, install the above dependencies by running the 
 ```bash
 #!/bin/bash
 git clone https://github.com/GoogleCloudPlatform/cloud-data-quality
-bash scripts/install_development_dependencies.sh
+source scripts/install_development_dependencies.sh
 ```
 
 ### Building a self-contained executable from source
@@ -446,7 +446,7 @@ If running `make build` fails due to missing shared library dependencies (e.g. `
 
 ```bash
 #!/bin/bash
-bash scripts/install_development_dependencies.sh
+source scripts/install_development_dependencies.sh
 ```
 
 ### 2. Wrong `glibc` version
@@ -466,7 +466,7 @@ From a `Ubuntu`/`Debian` machine, install the above dependencies by running the 
 
 ```bash
 #!/bin/bash
-bash scripts/install_development_dependencies.sh
+source scripts/install_development_dependencies.sh
 ```
 
 ## Feedback / Questions


### PR DESCRIPTION
existing [script](https://github.com/GoogleCloudPlatform/cloud-data-quality/blob/main/scripts/install_development_dependencies.sh#L45) installs golang and updates PATH variable to point to installed location

executing the script via:

`bash scripts/install_development_dependencies.sh`

opens a new shell, executes commands in that new shell and only returns output to the current shell. Any changes made to the environment, e.g. the PATH environment variable, only take place in the new shell. 

What's required is to make changes to the current shell of the user, such that the PATH variable of the current shell points to the newly installed golang for example. [ref](https://superuser.com/questions/176783/what-is-the-difference-between-executing-a-bash-script-vs-sourcing-it)

To do this, the script should be sourced like so: 

`source scripts/install_development_dependencies.sh`

This will run the commands in the script in the current user shell.


