### PR TITLE
Fix for go lang env missing after running install_development_dependencies

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export GO=/usr/local/go/bin
+export PATH=$PATH:$GO

--- a/scripts/install_development_dependencies.sh
+++ b/scripts/install_development_dependencies.sh
@@ -43,5 +43,5 @@ zip unzip python3-pip python3-venv
 curl -Lo  /tmp/go1.16.5.linux-amd64.tar.gz https://golang.org/dl/go1.16.5.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf /tmp/go1.16.5.linux-amd64.tar.gz
-export PATH=$PATH:/usr/local/go/bin
+. "$ROOT/scripts/env.sh"
 go version


### PR DESCRIPTION
Currently after running "install_development_dependencies.sh" go is unaccessible.

Fix includes creating a common "env.sh" to store any commonly use enviroment variables. install_development_dependencies.sh will call the env.sh to set the go enviroment.