### PR TITLE
better error

### DIFF
--- a/clouddq/classes/dq_configs_cache.py
+++ b/clouddq/classes/dq_configs_cache.py
@@ -185,10 +185,16 @@ class DqConfigsCache:
                     f"Calling Dataplex Metadata list entities API to retrieve schema "
                     f"for entity_uri:\n{pformat(record)}"
                 )
-                entity_uri = dq_entity_uri.EntityUri.from_uri(
-                    uri_string=record["entity_uri"],
-                    default_configs=default_configs,
-                )
+                try:
+                    entity_uri = dq_entity_uri.EntityUri.from_uri(
+                        uri_string=record["entity_uri"],
+                        default_configs=default_configs,
+                    )
+                except Exception as e:
+                    raise ValueError(
+                        "Failed to parse 'entity_uri' from rule_binding ID "
+                        f"'{record['id']}' with error:\n{e}"
+                    )
                 logger.debug(
                     f"Parsed entity_uri configs:\n{pformat(entity_uri.to_dict())}"
                 )

--- a/clouddq/classes/dq_entity.py
+++ b/clouddq/classes/dq_entity.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pprint import pformat
 
 import logging
 
@@ -113,10 +114,12 @@ class DqEntity:
 
         """
 
-        dq_column_config = self.columns.get(column_id, None)
+        dq_column_config = self.columns.get(column_id.upper(), None)
         assert_not_none_or_empty(
             dq_column_config,
-            f"Column ID: {column_id} not found in Entity Config: {self.entity_id}.",
+            f"Column ID '{column_id.upper()}' not found in Entity Config ID '{self.entity_id}'\n"
+            f"Available column_ids:\n{pformat(list(self.columns.keys()))}\n"
+            f"Complete entity configs:\n{pformat(self.dict_values())}.",
         )
         return dq_column_config
 
@@ -161,11 +164,11 @@ class DqEntity:
         columns: dict[str, DqEntityColumn] = dict()
         for column_id, column_config in columns_dict.items():
             column = DqEntityColumn.from_dict(
-                entity_column_id=column_id,
+                entity_column_id=column_id.upper(),
                 kwargs=column_config,
                 entity_source_database=source_database,
             )
-            columns[column_id] = column
+            columns[column_id.upper()] = column
         # validate environment override
         environment_override = dict()
         input_environment_override = kwargs.get("environment_override", None)

--- a/clouddq/classes/dq_entity_uri.py
+++ b/clouddq/classes/dq_entity_uri.py
@@ -62,6 +62,13 @@ class EntityUri:
     def from_uri(
         cls: EntityUri, uri_string: str, default_configs: dict | None = None
     ) -> EntityUri:
+        if "://" not in uri_string:
+            raise ValueError(
+                f"Invalid entity_uri: {uri_string}\n"
+                "Example valid URI: "
+                "dataplex://projects/project-id/locations/us-central1/"
+                "lakes/lake-id/zones/zone-id/entities/entity-id"
+            )
         uri_scheme, uri_configs_string = uri_string.split("://")
         scheme = EntityUriScheme.from_scheme(uri_scheme)
         default_scheme_configs = None

--- a/clouddq/classes/dq_rule.py
+++ b/clouddq/classes/dq_rule.py
@@ -30,11 +30,21 @@ class DqRule:
     params: dict | None = None
 
     @classmethod
-    def validate(cls: DqRule, config: dict, rule_dims: list) -> None:
+    def validate(cls: DqRule, config_id: str, config: dict, rule_dims: list) -> None:
         if "dimension" in config and not config["dimension"] in rule_dims:
             raise ValueError(
-                f"Rule is invalid because dimension '{config['dimension']}'"
-                f" does not appear in the list of rule_dimensions: {rule_dims}"
+                f"Invalid rule dimension '{config['dimension']}' in "
+                f"rule configurations ID '{config_id}'.\n"
+                f"Ensure it is one of the allowed rule_dimensions: {rule_dims} or add it to"
+                f"the allowed list of dimensions in the 'rule_dimensions' YAML node, e.g.\n"
+                f"```\nrule_dimensions:\n"
+                f"  - consistency\n"
+                f"  - correctness\n"
+                f"  - duplication\n"
+                f"  - completeness\n"
+                f"  - conformance\n"
+                f"  - integrity\n"
+                f"```"
             )
 
     @classmethod

--- a/clouddq/classes/dq_rule.py
+++ b/clouddq/classes/dq_rule.py
@@ -31,21 +31,37 @@ class DqRule:
 
     @classmethod
     def validate(cls: DqRule, config_id: str, config: dict, rule_dims: list) -> None:
-        if "dimension" in config and not config["dimension"] in rule_dims:
-            raise ValueError(
-                f"Invalid rule dimension '{config['dimension']}' in "
-                f"rule configurations ID '{config_id}'.\n"
-                f"Ensure it is one of the allowed rule_dimensions: {rule_dims} or add it to"
-                f"the allowed list of dimensions in the 'rule_dimensions' YAML node, e.g.\n"
-                f"```\nrule_dimensions:\n"
-                f"  - consistency\n"
-                f"  - correctness\n"
-                f"  - duplication\n"
-                f"  - completeness\n"
-                f"  - conformance\n"
-                f"  - integrity\n"
-                f"```"
-            )
+        if "dimension" in config:
+            if not rule_dims:
+                raise ValueError(
+                    f"Invalid rule dimension '{config['dimension']}' in "
+                    f"rule configurations ID '{config_id}'.\n"
+                    f"The list of allowed rule_dimensions is empty. You can add '{config['dimension']}' to"
+                    f"the allowed list of dimensions in the 'rule_dimensions' YAML config node, e.g.\n"
+                    f"```\nrule_dimensions:\n"
+                    f"  - consistency\n"
+                    f"  - correctness\n"
+                    f"  - duplication\n"
+                    f"  - completeness\n"
+                    f"  - conformance\n"
+                    f"  - integrity\n"
+                    f"```"
+                )
+            if not config["dimension"] in rule_dims:
+                raise ValueError(
+                    f"Invalid rule dimension '{config['dimension']}' in "
+                    f"rule configurations ID '{config_id}'.\n"
+                    f"Ensure it is one of the allowed rule_dimensions: {rule_dims} or add it to"
+                    f"the allowed list of dimensions in the 'rule_dimensions' YAML config node, e.g.\n"
+                    f"```\nrule_dimensions:\n"
+                    f"  - consistency\n"
+                    f"  - correctness\n"
+                    f"  - duplication\n"
+                    f"  - completeness\n"
+                    f"  - conformance\n"
+                    f"  - integrity\n"
+                    f"```"
+                )
 
     @classmethod
     def from_dict(cls: DqRule, rule_id: str, kwargs: dict) -> DqRule:

--- a/clouddq/classes/dq_rule_binding.py
+++ b/clouddq/classes/dq_rule_binding.py
@@ -110,6 +110,12 @@ class DqRuleBinding:
         if incremental_time_filter_column_id:
             incremental_time_filter_column_id.upper()
         metadata: dict | None = kwargs.get("metadata", dict())
+        if type(metadata) != dict:
+            raise ValueError(
+                f"Rule Binding ID: '{rule_binding_id}' has invalid "
+                f"metadata field with type {type(metadata)} and values: {metadata}\n"
+                "'metadata' must be of type dictionary."
+            )
         return DqRuleBinding(
             rule_binding_id=str(rule_binding_id).upper(),
             entity_id=entity_id,
@@ -253,57 +259,61 @@ class DqRuleBinding:
         Returns:
 
         """
-
-        # Resolve table configs
-        table_entity: DqEntity = self.resolve_table_entity_config(configs_cache)
-        # Resolve column configs
-        column_configs: DqEntityColumn = table_entity.resolve_column_config(
-            self.column_id.upper()
-        )
-        incremental_time_filter_column = None
-        if self.incremental_time_filter_column_id:
-            incremental_time_filter_column_config: DqEntityColumn = (
-                table_entity.resolve_column_config(
-                    self.incremental_time_filter_column_id
-                )
+        try:
+            # Resolve table configs
+            table_entity: DqEntity = self.resolve_table_entity_config(configs_cache)
+            # Resolve column configs
+            column_configs: DqEntityColumn = table_entity.resolve_column_config(
+                self.column_id.upper()
             )
-            incremental_time_filter_column_type: str = (
-                incremental_time_filter_column_config.get_column_type_value()
+            incremental_time_filter_column = None
+            if self.incremental_time_filter_column_id:
+                incremental_time_filter_column_config: DqEntityColumn = (
+                    table_entity.resolve_column_config(
+                        self.incremental_time_filter_column_id.upper()
+                    )
+                )
+                incremental_time_filter_column_type: str = (
+                    incremental_time_filter_column_config.get_column_type_value()
+                )
+                if incremental_time_filter_column_type not in ("TIMESTAMP", "DATETIME"):
+                    raise ValueError(
+                        f"incremental_time_filter_column_id: "
+                        f"{self.incremental_time_filter_column_id} "
+                        f"must have type TIMESTAMP or DATETIME.\n"
+                        f"Current type: {incremental_time_filter_column_type}."
+                    )
+                incremental_time_filter_column = dict(
+                    incremental_time_filter_column_config.dict_values()
+                ).get("name")
+            # Resolve rules configs
+            rule_configs_dict = dict()
+            for rule in self.resolve_rule_config_list(configs_cache):
+                for rule_id, rule_config in rule.to_dict().items():
+                    rule_id = rule_id.upper()
+                    rule_sql_expr = Template(
+                        rule_config["rule_sql_expr"]
+                    ).safe_substitute(column=column_configs.column_name)
+                    rule_config["rule_sql_expr"] = rule_sql_expr
+                    rule_configs_dict[rule_id] = rule_config
+            # Resolve filter configs
+            row_filter_config = self.resolve_row_filter_config(configs_cache)
+            return dict(
+                {
+                    "rule_binding_id": self.rule_binding_id,
+                    "entity_id": self.entity_id,
+                    "entity_configs": dict(table_entity.dict_values()),
+                    "column_id": self.column_id,
+                    "column_configs": dict(column_configs.dict_values()),
+                    "rule_ids": list(self.rule_ids),
+                    "rule_configs_dict": rule_configs_dict,
+                    "row_filter_id": self.row_filter_id,
+                    "row_filter_configs": dict(row_filter_config.dict_values()),
+                    "incremental_time_filter_column": incremental_time_filter_column,
+                    "metadata": self.metadata,
+                }
             )
-            if incremental_time_filter_column_type not in ("TIMESTAMP", "DATETIME"):
-                raise ValueError(
-                    f"incremental_time_filter_column_id: "
-                    f"{self.incremental_time_filter_column_id} "
-                    f"must have type TIMESTAMP or DATETIME.\n"
-                    f"Current type: {incremental_time_filter_column_type}."
-                )
-            incremental_time_filter_column = dict(
-                incremental_time_filter_column_config.dict_values()
-            ).get("name")
-        # Resolve rules configs
-        rule_configs_dict = dict()
-        for rule in self.resolve_rule_config_list(configs_cache):
-            for rule_id, rule_config in rule.to_dict().items():
-                rule_id = rule_id.upper()
-                rule_sql_expr = Template(rule_config["rule_sql_expr"]).safe_substitute(
-                    column=column_configs.column_name
-                )
-                rule_config["rule_sql_expr"] = rule_sql_expr
-                rule_configs_dict[rule_id] = rule_config
-        # Resolve filter configs
-        row_filter_config = self.resolve_row_filter_config(configs_cache)
-        return dict(
-            {
-                "rule_binding_id": self.rule_binding_id,
-                "entity_id": self.entity_id,
-                "entity_configs": dict(table_entity.dict_values()),
-                "column_id": self.column_id,
-                "column_configs": dict(column_configs.dict_values()),
-                "rule_ids": list(self.rule_ids),
-                "rule_configs_dict": rule_configs_dict,
-                "row_filter_id": self.row_filter_id,
-                "row_filter_configs": dict(row_filter_config.dict_values()),
-                "incremental_time_filter_column": incremental_time_filter_column,
-                "metadata": self.metadata,
-            }
-        )
+        except Exception as error:
+            raise ValueError(
+                f"Failed to resolve Rule Binding ID '{self.rule_binding_id}' with error:\n{error}"
+            )

--- a/clouddq/integration/dataplex/clouddq_dataplex.py
+++ b/clouddq/integration/dataplex/clouddq_dataplex.py
@@ -295,8 +295,8 @@ class CloudDqDataplexClient:
         else:
             raise RuntimeError(
                 f"Failed to retrieve Dataplex entity: "
-                f"'/projects/{self._client.gcp_project_id}/locations/{self._client.location_id}"
-                f"/lakes/{self._client.lake_name}/zones/{zone_id}/entities/{entity_id}':\n {response.text}"
+                f"'/projects/{gcp_project_id}/locations/{location_id}"
+                f"/lakes/{lake_name}/zones/{zone_id}/entities/{entity_id}':\n {response.text}"
             )
 
     def list_dataplex_entities(

--- a/clouddq/lib.py
+++ b/clouddq/lib.py
@@ -175,8 +175,8 @@ def prepare_configs_cache(configs_path: Path) -> DqConfigsCache:
     rules_collection = load_rules_config(configs_path)
 
     # validate rules against dimensions
-    for rule in rules_collection.values():
-        DqRule.validate(rule, rule_dimensions_collection)
+    for rule_id, rule in rules_collection.items():
+        DqRule.validate(rule_id, rule, rule_dimensions_collection)
 
     configs_cache.load_all_rules_collection(rules_collection)
     rule_binding_collection = load_rule_bindings_config(configs_path)

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -249,6 +249,21 @@ class TestClasses:
                 kwargs=dq_rule_binding_dict_not_valid,
             )
 
+    def test_dq_rule_binding_invalid_metadata_failure(self):
+        """ """
+        dq_rule_binding_dict_not_valid = {
+            "entity_id": "valid",
+            "column_id": "valid",
+            "row_filter_id": "valid",
+            "rule_ids": ["rule1", "rule2"],
+            "metadata": None,
+        }
+        with pytest.raises(ValueError):
+            DqRuleBinding.from_dict(
+                rule_binding_id="valid",
+                kwargs=dq_rule_binding_dict_not_valid,
+            )
+
     def test_rule_type_not_implemented(self):
         """ """
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
This fixes:

1. DataplexClient.get_dataplex_entity() error currently uses the client project-id instead of the project-id provided in the entity_uri
2. add an example rules_dimensions: node to the error message returned by DqRule.validate()
3. EntityUri.from_uri() reports a better error message if entity_uri does not contain the string '://'
4. DqEntity.from_dict() reports a better error message if the input 'metadata' field is not of type dict.
5. DqEntity.resolve_column_config() reports a better error message if the 'column_id' is not found in the entity columns.