### PR TITLE
Validation error of CUSTOM_SQL_STATEMENT without custom parameter

### DIFF
--- a/clouddq/classes/rule_type.py
+++ b/clouddq/classes/rule_type.py
@@ -120,9 +120,11 @@ def to_sql_custom_sql_statement(params: dict) -> Template:
                     f"custom_sql_arguments '{argument}' not found in "
                     f"input parameters:\n {params}"
                 )
-    custom_sql_statement = Template(custom_sql_statement).safe_substitute(
-        params.get("rule_binding_arguments")
-    )
+
+    if params.get("rule_binding_arguments"):
+        custom_sql_statement = Template(custom_sql_statement).safe_substitute(
+            params.get("rule_binding_arguments")
+        )
     check_for_invalid_sql(RuleType.CUSTOM_SQL_STATEMENT, custom_sql_statement)
     return Template(custom_sql_statement)
 

--- a/tests/resources/dq_rules_configs.yml
+++ b/tests/resources/dq_rules_configs.yml
@@ -18,6 +18,7 @@ metadata_registry_defaults:
     locations: <my-gcp-dataplex-region-id>
     lakes: <my-gcp-dataplex-lake-id>
     zones: <my-gcp-dataplex-zone-id>
+
 row_filters:
   DATA_TYPE_EMAIL:
     filter_sql_expr: contact_type = 'email'
@@ -25,6 +26,7 @@ row_filters:
     filter_sql_expr: 'True'
   NO_ROWS:
     filter_sql_expr: 'FALSE'
+
 entities:
   TEST_TABLE:
     source_database: BIGQUERY
@@ -58,6 +60,8 @@ entities:
         data_type: DATETIME
         description: |-
           updated timestamp
+
+
 rule_bindings:
   T1_DQ_1_VALUE_NOT_NULL:
     entity_id: TEST_TABLE
@@ -140,15 +144,27 @@ rule_bindings:
           column_names: "contact_type,value"
     metadata:
       brand: one
+  UNIQUENESS:
+    entity_id: TEST_TABLE
+    column_id: ROW_ID
+    row_filter_id: NONE
+    rule_ids:
+      - UNIQUE
+
+
 rules:
+
   CUSTOM_SQL_LENGTH_LE_30:
     params:
       custom_sql_expr: LENGTH( $column ) <= 30
     rule_type: CUSTOM_SQL_EXPR
+
   NOT_BLANK:
     rule_type: NOT_BLANK
+
   NOT_NULL_SIMPLE:
     rule_type: NOT_NULL
+
   NO_DUPLICATES_IN_COLUMN_GROUPS:
     params:
       custom_sql_arguments:
@@ -157,8 +173,16 @@ rules:
         \ $column_names\n  from data\n  group by $column_names\n  having count(*)\
         \ > 1\n) duplicates\nusing ($column_names)"
     rule_type: CUSTOM_SQL_STATEMENT
+
   REGEX_VALID_EMAIL:
     params:
       pattern: ^[^@]+[@]{1}[^@]+$
     rule_type: REGEX
 
+  UNIQUE:
+    rule_type: CUSTOM_SQL_STATEMENT
+    params:
+      custom_sql_statement: |-
+        select $column from data
+        group by $column
+        having count(*) > 1

--- a/tests/resources/dq_rules_expected_results.json
+++ b/tests/resources/dq_rules_expected_results.json
@@ -166,5 +166,19 @@
     "success_count": null,
     "failed_count": null,
     "null_count": null
-  }
+  },
+  {
+    "rule_binding_id": "UNIQUENESS",
+    "rule_id": "UNIQUE",
+    "column_id": null,
+    "dimension": null,
+    "metadata_json_string": "{}",
+    "progress_watermark": true,
+    "rows_validated": "9",
+    "complex_rule_validation_errors_count": "2",
+    "complex_rule_validation_success_flag": false,
+    "success_count": null,
+    "failed_count": null,
+    "null_count": null
+  } 
 ]


### PR DESCRIPTION
Currently a rule of type CUSTOM_SQL_STATEMENT cannot be used if it has no custom SQL parameters, because the validation fails. The error is:

```
ValueError: Failed to resolve Rule Binding ID 'UNIQUENESS' with error:
Failed to resolve rule_id 'UNIQUE' in rule_binding_id 'UNIQUENESS' with error:
'NoneType' object is not subscriptable
```

This PR fixes the problem and adds a test.

Note that if `params` is a dict containing a key `rule_binding_arguments` with a value of `None`, then `params.get('rule_binding_arguments', {})` will not return an empty dict, but None.