### PR TITLE
Dataproc image version upgrade

### DIFF
--- a/scripts/dataproc-workflow-composer/dataproc_workflow_template.yaml
+++ b/scripts/dataproc-workflow-composer/dataproc_workflow_template.yaml
@@ -42,7 +42,7 @@ placement:
           bootDiskSizeGb: 100
         machineTypeUri: n1-standard-4
       softwareConfig:
-        imageVersion: 2.0-ubuntu18
+        imageVersion: 2.0.27-ubuntu18
         properties:
           dataproc:dataproc.allow.zero.workers: 'true'
           dataproc:dataproc.logging.stackdriver.enable: 'true'


### PR DESCRIPTION
Upgrading to a recent minor version of dataproc image not impacted by log4j 2 vulnerability.

More details: https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.0