### PR TITLE
Fixing an issue with conflicting names: column_id=data with the CTE data alias

### DIFF
--- a/clouddq/classes/dq_rule_binding.py
+++ b/clouddq/classes/dq_rule_binding.py
@@ -304,7 +304,9 @@ class DqRuleBinding:
                     rule_id = rule_id.upper()
                     rule_sql_expr = Template(
                         rule_config["rule_sql_expr"]
-                    ).safe_substitute(column=column_configs.column_name)
+                    ).safe_substitute(column=
+                        column_configs.column_name if column_configs.column_name != "data"
+                        else f"data.{column_configs.column_name}")
                     rule_config["rule_sql_expr"] = rule_sql_expr
                     rule_configs_dict[rule_id] = rule_config
             # Resolve filter configs

--- a/tests/resources/configs/entities/test-data.yml
+++ b/tests/resources/configs/entities/test-data.yml
@@ -40,6 +40,11 @@ entities:
         data_type: STRING
         description: |-
           contact detail
+      DATA:
+        name: data
+        data_type: STRING
+        description: |-
+          custom data
       TS:
         name: ts
         data_type: DATETIME

--- a/tests/resources/expected_configs.json
+++ b/tests/resources/expected_configs.json
@@ -26,6 +26,11 @@
           "description": "contact detail",
           "name": "value",
           "data_type": "STRING"
+        },
+        "DATA": {
+          "description": "custom data",
+          "name": "data",
+          "data_type": "STRING"
         }
       },
       "database_name": "<your_bigquery_dataset_id>",

--- a/tests/unit/test_classes.py
+++ b/tests/unit/test_classes.py
@@ -15,6 +15,8 @@
 import logging
 
 import pytest
+from pathlib import Path
+import shutil
 
 from clouddq import lib
 from clouddq.classes.dq_configs_cache import DqConfigsCache
@@ -24,6 +26,7 @@ from clouddq.classes.dq_row_filter import DqRowFilter
 from clouddq.classes.dq_rule import DqRule
 from clouddq.classes.dq_rule_binding import DqRuleBinding
 from clouddq.classes.rule_type import RuleType
+from clouddq.utils import working_directory
 
 
 logger = logging.getLogger(__name__)
@@ -263,6 +266,48 @@ class TestClasses:
                 rule_binding_id="valid",
                 kwargs=dq_rule_binding_dict_not_valid,
             )
+
+    def test_dq_rule_binding_conflicted_column_id_is_escaped_for_sql_expr(self, temp_configs_dir, tmp_path):
+        try:
+            temp_dir = Path(tmp_path).joinpath("clouddq_test_configs_cache_2")
+            temp_dir.mkdir(parents=True)
+            with working_directory(temp_dir):
+                configs_cache = lib.prepare_configs_cache(temp_configs_dir)
+        finally:
+            shutil.rmtree(temp_dir)
+
+        dq_rule_binding_dict_with_conflicted_column_id = {
+            "entity_id": "TEST_TABLE",
+            "column_id": "data",
+            "row_filter_id": "NONE",
+            "rule_ids": ["REGEX_VALID_EMAIL"],
+            "metadata": {"key": "value"}
+        }
+
+        output = DqRuleBinding.from_dict(rule_binding_id="valid", kwargs=dq_rule_binding_dict_with_conflicted_column_id).resolve_all_configs_to_dict(configs_cache=configs_cache)
+
+        assert output["rule_configs_dict"]["REGEX_VALID_EMAIL"]["rule_sql_expr"] == "REGEXP_CONTAINS( CAST( data.data  AS STRING), '^[^@]+[@]{1}[^@]+$' )"
+    
+    def test_dq_rule_binding_conflicted_column_id_is_not_escaped_for_sql_statement(self, temp_configs_dir, tmp_path):
+        try:
+            temp_dir = Path(tmp_path).joinpath("clouddq_test_configs_cache_2")
+            temp_dir.mkdir(parents=True)
+            with working_directory(temp_dir):
+                configs_cache = lib.prepare_configs_cache(temp_configs_dir)
+        finally:
+            shutil.rmtree(temp_dir)
+
+        dq_rule_binding_dict_with_conflicted_column_id = {
+            "entity_id": "TEST_TABLE",
+            "column_id": "data",
+            "row_filter_id": "NONE",
+            "rule_ids": [{"NO_DUPLICATES_IN_COLUMN_GROUPS": {"column_names": "data"}}],
+            "metadata": {"key": "value"}
+        }
+
+        output = DqRuleBinding.from_dict(rule_binding_id="valid", kwargs=dq_rule_binding_dict_with_conflicted_column_id).resolve_all_configs_to_dict(configs_cache=configs_cache)
+
+        assert output["rule_configs_dict"]["NO_DUPLICATES_IN_COLUMN_GROUPS"]["rule_sql_expr"].replace('\n',' ') == "select a.* from data a inner join (   select     data   from data   group by data   having count(*) > 1 ) duplicates using (data)"
 
     def test_rule_type_not_implemented(self):
         """ """


### PR DESCRIPTION
This issue is specifically related to CUSTOM_SQL_EXPR which gets the column name (with no alias) and then uses it in the sql expression, e.g. REGEX check will only accepts the param of pattern. The substitution of column_id is done by the framework. In other cases, like CUSTOM_SQL_STATEMENT, the 'data' alias can be added to the sql, so there's no code change needed.