### PR TITLE
bq client supports different regions

### DIFF
--- a/clouddq/main.py
+++ b/clouddq/main.py
@@ -329,16 +329,24 @@ def main(  # noqa: C901
         )
         dq_summary_table_exists = False
         if gcp_region_id and not skip_sql_validation:
-            dq_summary_dataset = ".".join(dq_summary_table_name.split(".")[:2])
-            logger.debug(f"dq_summary_dataset: {dq_summary_dataset}")
+            dq_summary_table_ref = bigquery_client.table_from_string(
+                dq_summary_table_name
+            )
+            dq_summary_project_id = dq_summary_table_ref.project
+            dq_summary_dataset = dq_summary_table_ref.dataset_id
+            logger.info(
+                f"Using dq_summary_dataset: {dq_summary_project_id}.{dq_summary_dataset}"
+            )
             bigquery_client.assert_dataset_is_in_region(
-                dataset=dq_summary_dataset, region=gcp_region_id
+                dataset=dq_summary_dataset,
+                region=gcp_region_id,
+                project_id=dq_summary_project_id,
             )
             dq_summary_table_exists = bigquery_client.is_table_exists(
-                dq_summary_table_name
+                table=dq_summary_table_name, project_id=dq_summary_project_id
             )
             bigquery_client.assert_required_columns_exist_in_table(
-                dq_summary_table_name
+                table=dq_summary_table_name, project_id=dq_summary_project_id
             )
         # Check existence of dataset for target BQ table in the selected GCP region
         if target_bigquery_summary_table:
@@ -349,21 +357,26 @@ def main(  # noqa: C901
             target_table_ref = bigquery_client.table_from_string(
                 target_bigquery_summary_table
             )
+            target_project_id = target_table_ref.project
             target_dataset_id = target_table_ref.dataset_id
             logger.debug(
-                f"BigQuery dataset used in --target_bigquery_summary_table: {target_dataset_id}"
+                f"BigQuery dataset used in --target_bigquery_summary_table: {target_project_id}.{target_dataset_id}"
             )
-            if not bigquery_client.is_dataset_exists(target_dataset_id):
+            if not bigquery_client.is_dataset_exists(
+                dataset=target_dataset_id, project_id=target_project_id
+            ):
                 raise AssertionError(
                     "Invalid argument to --target_bigquery_summary_table: "
                     f"{target_bigquery_summary_table}. "
-                    f"Dataset {target_dataset_id} does not exist. "
+                    f"Dataset {target_project_id}.{target_dataset_id} does not exist. "
                 )
             bigquery_client.assert_dataset_is_in_region(
-                dataset=target_dataset_id, region=gcp_region_id
+                dataset=target_dataset_id,
+                region=gcp_region_id,
+                project_id=target_project_id,
             )
             bigquery_client.assert_required_columns_exist_in_table(
-                target_bigquery_summary_table
+                table=target_bigquery_summary_table, project_id=target_project_id
             )
         else:
             logger.warning(

--- a/tests/integration/test_bigquery_client.py
+++ b/tests/integration/test_bigquery_client.py
@@ -38,10 +38,54 @@ class TestBigQueryClient:
         query = "SELECT 1 + 2"
         client.check_query_dry_run(query)
 
+    def test_assert_is_dataset_exists(self, client):
+        table_name = "bigquery-public-data.github_repos.commits"
+        table_ref = client.table_from_string(
+            table_name
+        )
+        project_id = table_ref.project
+        dataset_id = table_ref.dataset_id
+        assert client.is_dataset_exists(dataset=dataset_id, project_id=project_id) is True
+
+    def test_assert_is_dataset_exists_implicit_project_id(self, client, gcp_dataplex_bigquery_dataset_id):
+        assert client.is_dataset_exists(dataset=gcp_dataplex_bigquery_dataset_id) is True
+
     def test_assert_dataset_is_in_region(self, client):
         dataset = "bigquery-public-data.google_analytics_sample"
         region = "US"
         client.assert_dataset_is_in_region(dataset=dataset, region=region)
+
+    def test_assert_is_table_exists(self, client):
+        table_name = "bigquery-public-data.github_repos.commits"
+        table_ref = client.table_from_string(
+            table_name
+        )
+        project_id = table_ref.project
+        assert client.is_table_exists(table=table_name, project_id=project_id) is True
+
+    def test_assert_is_table_exists_implicit_project_id(self,
+            client,
+            gcp_project_id,
+            target_bq_result_dataset_name,
+            target_bq_result_table_name):
+        table = f"{gcp_project_id}.{target_bq_result_dataset_name}.{target_bq_result_table_name}"
+        assert client.is_table_exists(table=table) is True
+
+    def test_assert_required_columns_exist_in_table(self,
+            client,
+            gcp_project_id,
+            target_bq_result_dataset_name,
+            target_bq_result_table_name):
+        table = f"{gcp_project_id}.{target_bq_result_dataset_name}.{target_bq_result_table_name}"
+        client.assert_required_columns_exist_in_table(table=table, project_id=gcp_project_id)
+
+    def test_assert_required_columns_exist_in_table_implicit_project_id(self,
+            client,
+            gcp_project_id,
+            target_bq_result_dataset_name,
+            target_bq_result_table_name):
+        table = f"{gcp_project_id}.{target_bq_result_dataset_name}.{target_bq_result_table_name}"
+        client.assert_required_columns_exist_in_table(table=table)
 
     def test_assert_dataset_is_in_region_failure(self, client):
         dataset = "bigquery-public-data.google_analytics_sample"


### PR DESCRIPTION
Fixes a bug with BQ Client validation using the current project id to validate datasets in different regions.