### PR TITLE
add RECORD type

### DIFF
--- a/clouddq/classes/dq_entity_column.py
+++ b/clouddq/classes/dq_entity_column.py
@@ -175,6 +175,7 @@ class DatabaseColumnType(str, Enum):
     TIME = "TIME"
     ARRAY = "ARRAY"
     STRUCT = "STRUCT"
+    RECORD = "RECORD"
     BINARY = "BINARY"
     BYTES = "BYTES"
     INTERVAL = "INTERVAL"
@@ -211,6 +212,7 @@ BIGQUERY_COLUMN_TYPES_MAPPING: dict = {
     DatabaseColumnType.TIME: "TIME",
     DatabaseColumnType.ARRAY: "ARRAY",
     DatabaseColumnType.STRUCT: "STRUCT",
+    DatabaseColumnType.RECORD: "STRUCT",
     DatabaseColumnType.BINARY: "BYTES",
     DatabaseColumnType.BYTES: "BYTES",
     DatabaseColumnType.INTERVAL: None,  # BQ has no INTERVAL type


### PR DESCRIPTION
Fix error `ValueError: 'RECORD' is not a valid DatabaseColumnType` when using entity_uri but not when using entity_id. 